### PR TITLE
Cleanup

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -12,6 +12,7 @@ jobs:
     uses: pyTooling/Actions/.github/workflows/Parameters.yml@r0
     with:
       name: pyEDAA.IPXACT
+      python_version_list: "3.6 3.7 3.8 3.9 3.10"
 
   Package:
     uses: pyTooling/Actions/.github/workflows/Package.yml@r0

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyEDAA.IPXACT?longCache=true&style=flat-square&logo=PyPI&logoColor=FBE072)  
 [![GitHub Workflow - Build and Test Status](https://img.shields.io/github/workflow/status/edaa-org/pyEDAA.IPXACT/Pipeline/main?longCache=true&style=flat-square&label=Build%20and%20Test&logo=GitHub%20Actions&logoColor=FFFFFF)](https://GitHub.com/edaa-org/pyEDAA.IPXACT/actions/workflows/Pipeline.yml)
 [![Libraries.io status for latest release](https://img.shields.io/librariesio/release/pypi/pyEDAA.IPXACT?longCache=true&style=flat-square&logo=Libraries.io&logoColor=fff)](https://libraries.io/github/edaa-org/pyEDAA.IPXACT)
+[![Codacy - Quality](https://img.shields.io/codacy/grade/c924eeffd4cc49ed9ebbbe3a89b6fa76?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pyEDAA.IPXACT)
 
 
 <!--
-[![Codacy - Quality](https://img.shields.io/codacy/grade/3deb3840b05b40bf935380b41074bea9?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pyEDAA.IPXACT)
-[![Codacy - Coverage](https://img.shields.io/codacy/coverage/3deb3840b05b40bf935380b41074bea9?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pyEDAA.IPXACT)
+[![Codacy - Coverage](https://img.shields.io/codacy/coverage/c924eeffd4cc49ed9ebbbe3a89b6fa76?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pyEDAA.IPXACT)
 [![Codecov - Branch Coverage](https://img.shields.io/codecov/c/github/edaa-org/pyEDAA.IPXACT?longCache=true&style=flat-square&logo=Codecov)](https://codecov.io/gh/edaa-org/pyEDAA.IPXACT)
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,13 +45,6 @@ extensions = [
 	'sphinx.ext.mathjax',
 	'sphinx.ext.ifconfig',
 	'sphinx.ext.viewcode',
-# SphinxContrib extensions
-
-# Other extensions
-#	'DocumentMember',
-# local extensions (patched)
-
-# local extensions
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,17 +17,17 @@
 
    |  |SHIELD:svg:IPXACT-github| |SHIELD:svg:IPXACT-src-license| |SHIELD:svg:IPXACT-ghp-doc| |SHIELD:svg:IPXACT-doc-license| |SHIELD:svg:IPXACT-gitter|
    |  |SHIELD:svg:IPXACT-pypi-tag| |SHIELD:svg:IPXACT-pypi-status| |SHIELD:svg:IPXACT-pypi-python|
-   |  |SHIELD:svg:IPXACT-gha-test| |SHIELD:svg:IPXACT-lib-status|
+   |  |SHIELD:svg:IPXACT-gha-test| |SHIELD:svg:IPXACT-lib-status| |SHIELD:svg:IPXACT-codacy-quality|
 
-.. Disabled shields: |SHIELD:svg:IPXACT-codacy-quality| |SHIELD:svg:IPXACT-codacy-coverage| |SHIELD:svg:IPXACT-codecov-coverage| |SHIELD:svg:IPXACT-lib-dep| |SHIELD:svg:IPXACT-req-status| |SHIELD:svg:IPXACT-lib-rank|
+.. Disabled shields: |SHIELD:svg:IPXACT-codacy-coverage| |SHIELD:svg:IPXACT-codecov-coverage| |SHIELD:svg:IPXACT-lib-dep| |SHIELD:svg:IPXACT-req-status| |SHIELD:svg:IPXACT-lib-rank|
 
 .. only:: latex
 
    |SHIELD:png:IPXACT-github| |SHIELD:png:IPXACT-src-license| |SHIELD:png:IPXACT-ghp-doc| |SHIELD:png:IPXACT-doc-license| |SHIELD:png:IPXACT-gitter|
    |SHIELD:png:IPXACT-pypi-tag| |SHIELD:png:IPXACT-pypi-status| |SHIELD:png:IPXACT-pypi-python|
-   |SHIELD:png:IPXACT-gha-test| |SHIELD:png:IPXACT-lib-status|
+   |SHIELD:png:IPXACT-gha-test| |SHIELD:png:IPXACT-lib-status| |SHIELD:png:IPXACT-codacy-quality|
 
-.. Disabled shields: |SHIELD:png:IPXACT-codacy-quality| |SHIELD:png:IPXACT-codacy-coverage| |SHIELD:png:IPXACT-codecov-coverage| |SHIELD:png:IPXACT-lib-dep| |SHIELD:png:IPXACT-req-status| |SHIELD:png:IPXACT-lib-rank|
+.. Disabled shields: |SHIELD:png:IPXACT-codacy-coverage| |SHIELD:png:IPXACT-codecov-coverage| |SHIELD:png:IPXACT-lib-dep| |SHIELD:png:IPXACT-req-status| |SHIELD:png:IPXACT-lib-rank|
 
 pyEDAA.IPXACT Documentation
 ###########################

--- a/doc/shields.inc
+++ b/doc/shields.inc
@@ -54,21 +54,21 @@
    :target: https://GitHub.com/edaa-org/pyEDAA.IPXACT/actions/workflows/Pipeline.yml
 
 .. # Codacy - quality
-.. |SHIELD:svg:IPXACT-codacy-quality| image:: https://img.shields.io/codacy/grade/3deb3840b05b40bf935380b41074bea9?longCache=true&style=flat-square&logo=codacy
+.. |SHIELD:svg:IPXACT-codacy-quality| image:: https://img.shields.io/codacy/grade/c924eeffd4cc49ed9ebbbe3a89b6fa76?longCache=true&style=flat-square&logo=codacy
    :alt: Codacy - Quality
    :height: 22
    :target: https://www.codacy.com/gh/edaa-org/pyEDAA.IPXACT
-.. |SHIELD:png:IPXACT-codacy-quality| image:: https://raster.shields.io/codacy/grade/3deb3840b05b40bf935380b41074bea9?longCache=true&style=flat-square&logo=codacy
+.. |SHIELD:png:IPXACT-codacy-quality| image:: https://raster.shields.io/codacy/grade/c924eeffd4cc49ed9ebbbe3a89b6fa76?longCache=true&style=flat-square&logo=codacy
    :alt: Codacy - Quality
    :height: 22
    :target: https://www.codacy.com/gh/edaa-org/pyEDAA.IPXACT
 
 .. # Codacy - coverage
-.. |SHIELD:svg:IPXACT-codacy-coverage| image:: https://img.shields.io/codacy/coverage/3deb3840b05b40bf935380b41074bea9?longCache=true&style=flat-square&logo=codacy
+.. |SHIELD:svg:IPXACT-codacy-coverage| image:: https://img.shields.io/codacy/coverage/c924eeffd4cc49ed9ebbbe3a89b6fa76?longCache=true&style=flat-square&logo=codacy
    :alt: Codacy - Line Coverage
    :height: 22
    :target: https://www.codacy.com/gh/edaa-org/pyEDAA.IPXACT
-.. |SHIELD:png:IPXACT-codacy-coverage| image:: https://raster.shields.io/codacy/coverage/3deb3840b05b40bf935380b41074bea9?longCache=true&style=flat-square&logo=codacy
+.. |SHIELD:png:IPXACT-codacy-coverage| image:: https://raster.shields.io/codacy/coverage/c924eeffd4cc49ed9ebbbe3a89b6fa76?longCache=true&style=flat-square&logo=codacy
    :alt: Codacy - Line Coverage
    :height: 22
    :target: https://www.codacy.com/gh/edaa-org/pyEDAA.IPXACT


### PR DESCRIPTION
# Changes

* ci/Params: override python_version_list, since 3.6 was deprecated in pyTooling/Actions.
* doc: update codacy shields.
